### PR TITLE
Self Gravity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set( ATHELAS_SOURCES
   "src/radiation/radhydro_package.cpp"
   "src/radiation/rad_utilities.cpp"
   "src/geometry/grid.cpp"
+  "src/gravity/gravity_package.cpp"
   "src/io/io.cpp"
   "src/linalg/linear_algebra.cpp"
   "src/quadrature/quadrature.cpp"

--- a/inputs/sedov.toml
+++ b/inputs/sedov.toml
@@ -4,6 +4,7 @@ t_end = 0.05
 geometry = "spherical"
 restart = false
 do_rad = false
+do_gravity = false
 xl = 0.0
 xr = 1.0
 cfl = 0.25
@@ -34,6 +35,10 @@ nnodes = 3
 porder = 3
 nx = 256
 ng = 1
+
+[gravity]
+model = "constant"
+gval = 1.0
 
 [time]
 integrator = "EX_SSPRK54"

--- a/src/basis/polynomial_basis.cpp
+++ b/src/basis/polynomial_basis.cpp
@@ -39,6 +39,7 @@ ModalBasis::ModalBasis(poly_basis::poly_basis basis, const View3D<double> uPF,
       dphi_("dphi_", nElements + 2 * nGuard, 3 * nN + 2, pOrder) {
   // --- Compute grid quantities ---
   grid->compute_mass(uPF);
+  grid->compute_mass_r(uPF); // Weird place for this to be but works
   grid->compute_center_of_mass(uPF);
 
   if (basis == poly_basis::legendre) {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -136,6 +136,7 @@ void Driver::initialize(const ProblemIn* pin) { // NOLINT
   }
 
   // --- Init physics package manager ---
+  // NOTE: Hydro/RadHydro should be registered first
   if (!pin->do_rad) {
     manager_->add_package(HydroPackage{pin, ssprk_.get_n_stages(), eos_.get(),
                                        fluid_basis_.get(), bcs_.get(), cfl_,
@@ -150,9 +151,11 @@ void Driver::initialize(const ProblemIn* pin) { // NOLINT
                                          fluid_basis_.get(), cfl_, true});
   }
   auto registered_pkgs = manager_->get_package_names();
+  std::print("# Registered Packages ::");
   for (auto name : registered_pkgs) {
-    std::println("Package Registered:: {}", name);
+    std::print(" {}", name);
   }
+  std::print("\n\n");
 
   // --- slope limiter to initial condition ---
   apply_slope_limiter(&sl_hydro_, state_.get_u_cf(), &grid_, fluid_basis_.get(),
@@ -166,6 +169,10 @@ void Driver::initialize(const ProblemIn* pin) { // NOLINT
                          analysis::total_internal_energy);
   history_->add_quantity("Total Kinetic Energy [erg]",
                          analysis::total_kinetic_energy);
+  if (pin->do_gravity) {
+    history_->add_quantity("Total Gravitational Energy [erg]",
+                           analysis::total_gravitational_energy);
+  }
   if (pin->do_rad) {
     history_->add_quantity("Total Radiation Momentum [g cm / s]",
                            analysis::total_rad_momentum);

--- a/src/fluid/hydro_package.cpp
+++ b/src/fluid/hydro_package.cpp
@@ -29,7 +29,7 @@ HydroPackage::HydroPackage(const ProblemIn* /*pin*/, int n_stages, EOS* eos,
 KOKKOS_FUNCTION
 void HydroPackage::update_explicit(const View3D<double> state,
                                    View3D<double> dU, const GridStructure& grid,
-                                   const TimeStepInfo& dt_info) {
+                                   const TimeStepInfo& dt_info) const {
   const auto& order = basis_->get_order();
   const auto& ilo   = grid.get_ilo();
   const auto& ihi   = grid.get_ihi();
@@ -72,7 +72,7 @@ KOKKOS_FUNCTION
 void HydroPackage::fluid_divergence(const View3D<double> state,
                                     View3D<double> dU,
                                     const GridStructure& grid,
-                                    const int stage) {
+                                    const int stage) const {
   const auto& nNodes = grid.get_n_nodes();
   const auto& order  = basis_->get_order();
   const auto& ilo    = grid.get_ilo();
@@ -184,7 +184,7 @@ void HydroPackage::fluid_divergence(const View3D<double> state,
 
 KOKKOS_FUNCTION
 void HydroPackage::fluid_geometry(const View3D<double> state, View3D<double> dU,
-                                  const GridStructure& grid) {
+                                  const GridStructure& grid) const {
   const int& nNodes = grid.get_n_nodes();
   const int& order  = basis_->get_order();
   const int& ilo    = grid.get_ilo();

--- a/src/fluid/hydro_package.hpp
+++ b/src/fluid/hydro_package.hpp
@@ -25,15 +25,16 @@ class HydroPackage {
 
   KOKKOS_FUNCTION
   void update_explicit(View3D<double> state, View3D<double> dU,
-                       const GridStructure& grid, const TimeStepInfo& dt_info);
+                       const GridStructure& grid,
+                       const TimeStepInfo& dt_info) const;
 
   KOKKOS_FUNCTION
   void fluid_divergence(const View3D<double> state, View3D<double> dU,
-                        const GridStructure& grid, int stage);
+                        const GridStructure& grid, int stage) const;
 
   KOKKOS_FUNCTION
   void fluid_geometry(const View3D<double> state, View3D<double> dU,
-                      const GridStructure& grid);
+                      const GridStructure& grid) const;
 
   [[nodiscard]] KOKKOS_FUNCTION auto
   min_timestep(const View3D<double> state, const GridStructure& grid,

--- a/src/geometry/grid.cpp
+++ b/src/geometry/grid.cpp
@@ -104,7 +104,7 @@ auto GridStructure::get_x_r() const noexcept -> double { return xR_; }
 KOKKOS_FUNCTION
 auto GridStructure::get_sqrt_gm(double X) const -> double {
   if (geometry_ == geometry::Spherical) {
-    return constants::FOURPI * X * X;
+    return X * X;
   }
   return 1.0;
 }

--- a/src/geometry/grid.cpp
+++ b/src/geometry/grid.cpp
@@ -26,7 +26,8 @@ GridStructure::GridStructure(const ProblemIn* pin)
       geometry_(pin->Geometry), nodes_("Nodes", pin->nNodes),
       weights_("weights_", pin->nNodes), centers_("Cetners", mSize_),
       widths_("widths_", mSize_), x_l_("Left Interface", mSize_ + 1),
-      mass_("Cell mass_", mSize_), center_of_mass_("Center of mass_", mSize_),
+      mass_("Cell mass_", mSize_), mass_r_("Enclosed mass", mSize_, nNodes_),
+      center_of_mass_("Center of mass_", mSize_),
       grid_("Grid", mSize_, nNodes_) {
   std::vector<double> tmp_nodes(nNodes_);
   std::vector<double> tmp_weights(nNodes_);
@@ -65,38 +66,48 @@ const double shape_function(const int interface, const double eta) {
 }
 
 // Give physical grid coordinate from a node.
+KOKKOS_FUNCTION
 auto GridStructure::node_coordinate(int iC, int iN) const -> double {
   return x_l_(iC) * shape_function(0, nodes_(iN)) +
          x_l_(iC + 1) * shape_function(1, nodes_(iN));
 }
 
 // Return cell center
+KOKKOS_FUNCTION
 auto GridStructure::get_centers(int iC) const -> double { return centers_(iC); }
 
 // Return cell width
+KOKKOS_FUNCTION
 auto GridStructure::get_widths(int iC) const -> double { return widths_(iC); }
 
 // Return cell mass
+KOKKOS_FUNCTION
 auto GridStructure::get_mass(int iX) const -> double { return mass_(iX); }
 
 // Return cell reference Center of mass_
+KOKKOS_FUNCTION
 auto GridStructure::get_center_of_mass(int iX) const -> double {
   return center_of_mass_(iX);
 }
 
 // Return given quadrature node
+KOKKOS_FUNCTION
 auto GridStructure::get_nodes(int nN) const -> double { return nodes_(nN); }
 
 // Return given quadrature weight
+KOKKOS_FUNCTION
 auto GridStructure::get_weights(int nN) const -> double { return weights_(nN); }
 
 // Accessor for xL
+KOKKOS_FUNCTION
 auto GridStructure::get_x_l() const noexcept -> double { return xL_; }
 
 // Accessor for xR
+KOKKOS_FUNCTION
 auto GridStructure::get_x_r() const noexcept -> double { return xR_; }
 
 // Accessor for SqrtGm
+KOKKOS_FUNCTION
 auto GridStructure::get_sqrt_gm(double X) const -> double {
   if (geometry_ == geometry::Spherical) {
     return X * X;
@@ -105,36 +116,44 @@ auto GridStructure::get_sqrt_gm(double X) const -> double {
 }
 
 // Accessor for x_l_
+KOKKOS_FUNCTION
 auto GridStructure::get_left_interface(int iX) const -> double {
   return x_l_(iX);
 }
 
 // Return nNodes_
+KOKKOS_FUNCTION
 auto GridStructure::get_n_nodes() const noexcept -> int { return nNodes_; }
 
 // Return nElements_
+KOKKOS_FUNCTION
 auto GridStructure::get_n_elements() const noexcept -> int {
   return nElements_;
 }
 
 // Return number of guard zones
+KOKKOS_FUNCTION
 auto GridStructure::get_guard() const noexcept -> int { return nGhost_; }
 
 // Return first physical zone
+KOKKOS_FUNCTION
 auto GridStructure::get_ilo() const noexcept -> int { return nGhost_; }
 
 // Return last physical zone
+KOKKOS_FUNCTION
 auto GridStructure::get_ihi() const noexcept -> int {
   return nElements_ + nGhost_ - 1;
 }
 
 // Return true if in spherical symmetry
+KOKKOS_FUNCTION
 auto GridStructure::do_geometry() const noexcept -> bool {
   return geometry_ == geometry::Spherical;
 }
 
 // Equidistant mesh
 // TODO(astrobarker): We will need to replace centers_ here, right?
+KOKKOS_FUNCTION
 void GridStructure::create_grid() {
 
   const int ilo = nGhost_; // first real zone
@@ -171,6 +190,7 @@ void GridStructure::create_grid() {
 /**
  * Compute cell masses
  **/
+KOKKOS_FUNCTION
 void GridStructure::compute_mass(View3D<double> uPF) {
   const int nNodes_ = get_n_nodes();
   const int ilo     = get_ilo();
@@ -197,8 +217,37 @@ void GridStructure::compute_mass(View3D<double> uPF) {
 }
 
 /**
+ * Compute enclosed masses
+ **/
+KOKKOS_FUNCTION
+void GridStructure::compute_mass_r(View3D<double> uPF) {
+  const int nNodes_ = get_n_nodes();
+  const int ilo     = get_ilo();
+  const int ihi     = get_ihi();
+
+  double mass = 0.0;
+  double X    = 0.0;
+
+  mass = 0.0;
+  for (int iX = ilo; iX <= ihi; ++iX) {
+    for (int iN = 0; iN < nNodes_; ++iN) {
+      X = node_coordinate(iX, iN);
+      mass += weights_(iN) * get_sqrt_gm(X) * uPF(0, iX, iN);
+      mass_r_(iX, iN) = mass * widths_(iX);
+    }
+  }
+}
+
+KOKKOS_FUNCTION
+auto GridStructure::enclosed_mass(const int iX, const int iN) const noexcept
+    -> double {
+  return mass_r_(iX, iN);
+}
+
+/**
  * Compute cell centers of masses reference coordinates
  **/
+KOKKOS_FUNCTION
 void GridStructure::compute_center_of_mass(View3D<double> uPF) {
   const int nNodes_ = get_n_nodes();
   const int ilo     = get_ilo();
@@ -227,6 +276,7 @@ void GridStructure::compute_center_of_mass(View3D<double> uPF) {
 /**
  * Update grid coordinates using interface velocities.
  **/
+KOKKOS_FUNCTION
 void GridStructure::update_grid(View1D<double> SData) {
 
   const int ilo = get_ilo();
@@ -250,8 +300,10 @@ void GridStructure::update_grid(View1D<double> SData) {
 }
 
 // Access by (element, node)
+KOKKOS_FUNCTION
 auto GridStructure::operator()(int i, int j) -> double& { return grid_(i, j); }
 
+KOKKOS_FUNCTION
 auto GridStructure::operator()(int i, int j) const -> double {
   return grid_(i, j);
 }

--- a/src/geometry/grid.cpp
+++ b/src/geometry/grid.cpp
@@ -228,12 +228,14 @@ void GridStructure::compute_mass_r(View3D<double> uPF) {
   double mass = 0.0;
   double X    = 0.0;
 
+  const double geom_fac = (do_geometry()) ? 4.0 * constants::PI : 1.0;
+
   mass = 0.0;
   for (int iX = ilo; iX <= ihi; ++iX) {
     for (int iN = 0; iN < nNodes_; ++iN) {
       X = node_coordinate(iX, iN);
       mass += weights_(iN) * get_sqrt_gm(X) * uPF(0, iX, iN);
-      mass_r_(iX, iN) = mass * widths_(iX);
+      mass_r_(iX, iN) = mass * widths_(iX) * geom_fac;
     }
   }
 }

--- a/src/geometry/grid.cpp
+++ b/src/geometry/grid.cpp
@@ -49,20 +49,14 @@ GridStructure::GridStructure(const ProblemIn* pin)
 
 // linear shape function on the reference element
 KOKKOS_INLINE_FUNCTION
-const double shape_function(const int interface, const double eta) {
-  double mult = 1.0;
-
+auto shape_function(const int interface, const double eta) -> const double {
   if (interface == 0) {
-    mult = -1.0;
+    return 1.0 * (0.5 - eta);
   }
   if (interface == 1) {
-    mult = +1.0;
+    return 1.0 * (0.5 + eta);
   }
-  if (interface != 0 && interface != 1) {
-    THROW_ATHELAS_ERROR(" ! Invalid shape func params");
-  }
-
-  return 0.5 + (mult * eta);
+  return 0.0; // unreachable, but silences warnings
 }
 
 // Give physical grid coordinate from a node.
@@ -110,7 +104,7 @@ auto GridStructure::get_x_r() const noexcept -> double { return xR_; }
 KOKKOS_FUNCTION
 auto GridStructure::get_sqrt_gm(double X) const -> double {
   if (geometry_ == geometry::Spherical) {
-    return X * X;
+    return constants::FOURPI * X * X;
   }
   return 1.0;
 }

--- a/src/geometry/grid.hpp
+++ b/src/geometry/grid.hpp
@@ -23,33 +23,62 @@
 class GridStructure {
  public:
   explicit GridStructure(const ProblemIn* pin);
+  GridStructure() = default;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto node_coordinate(int iC, int iN) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_centers(int iC) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_widths(int iC) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_nodes(int nN) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_weights(int nN) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_mass(int iX) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_center_of_mass(int iX) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_x_l() const noexcept -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_x_r() const noexcept -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_sqrt_gm(double X) const -> double;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_left_interface(int iX) const -> double;
 
+  KOKKOS_FUNCTION
   [[nodiscard]] auto do_geometry() const noexcept -> bool;
 
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_guard() const noexcept -> int;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_ilo() const noexcept -> int;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_ihi() const noexcept -> int;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_n_nodes() const noexcept -> int;
+  KOKKOS_FUNCTION
   [[nodiscard]] auto get_n_elements() const noexcept -> int;
 
+  KOKKOS_FUNCTION
   void create_grid();
+  KOKKOS_FUNCTION
   void update_grid(View1D<double> SData);
+  KOKKOS_FUNCTION
   void compute_mass(View3D<double> uPF);
+  KOKKOS_FUNCTION
+  void compute_mass_r(View3D<double> uPF);
+  KOKKOS_FUNCTION
+  auto enclosed_mass(const int iX, const int iN) const noexcept -> double;
+  KOKKOS_FUNCTION
   void compute_center_of_mass(View3D<double> uPF);
+  KOKKOS_FUNCTION
   void compute_center_of_mass_radius(View3D<double> uPF);
 
+  KOKKOS_FUNCTION
   auto operator()(int i, int j) -> double&;
+  KOKKOS_FUNCTION
   auto operator()(int i, int j) const -> double;
 
  private:
@@ -70,7 +99,8 @@ class GridStructure {
   View1D<double> widths_{};
   View1D<double> x_l_{}; // left interface coordinate
 
-  View1D<double> mass_{};
+  View1D<double> mass_{}; // cell mass
+  View2D<double> mass_r_{}; // enclosed mass
   View1D<double> center_of_mass_{};
 
   View2D<double> grid_{};

--- a/src/gravity/gravity_package.cpp
+++ b/src/gravity/gravity_package.cpp
@@ -1,0 +1,119 @@
+/**
+ * @file gravity_package.cpp
+ * --------------
+ *
+ * @brief Gravitational source package
+ **/
+#include <limits>
+
+#include "basis/polynomial_basis.hpp"
+#include "geometry/grid.hpp"
+#include "gravity/gravity_package.hpp"
+#include "pgen/problem_in.hpp"
+#include "utils/abstractions.hpp"
+
+namespace gravity {
+
+GravityPackage::GravityPackage(const ProblemIn* /*pin*/, GravityModel model,
+                               const double gval, ModalBasis* basis,
+                               const double cfl, const bool active)
+    : active_(active), model_(model), gval_(gval), basis_(basis), cfl_(cfl) {}
+
+KOKKOS_FUNCTION
+void GravityPackage::update_explicit(const View3D<double> state,
+                                     View3D<double> dU,
+                                     const GridStructure& grid,
+                                     const TimeStepInfo& /*dt_info*/) const {
+  if (model_ == GravityModel::Spherical) {
+    gravity_update<GravityModel::Spherical>(state, dU, grid);
+  } else [[unlikely]] {
+    gravity_update<GravityModel::Constant>(state, dU, grid);
+  }
+}
+
+KOKKOS_FUNCTION
+template <GravityModel Model>
+void GravityPackage::gravity_update(const View3D<double> state,
+                                    View3D<double> dU,
+                                    const GridStructure& grid) const {
+  const int& nNodes = grid.get_n_nodes();
+  const int& order  = basis_->get_order();
+  const int& ilo    = grid.get_ilo();
+  const int& ihi    = grid.get_ihi();
+
+  // This can probably be simplified.
+  if constexpr (Model == GravityModel::Spherical) {
+    Kokkos::parallel_for(
+        "Gravity :: Spherical update",
+        Kokkos::MDRangePolicy<Kokkos::Rank<2>>({ilo, 0}, {ihi + 1, order}),
+        KOKKOS_CLASS_LAMBDA(const int iX, const int k) {
+          double local_sum_v = 0.0;
+          double local_sum_e = 0.0;
+          for (int iN = 0; iN < nNodes; ++iN) {
+            const double X = grid.node_coordinate(iX, iN);
+
+            local_sum_v +=
+                grid.get_weights(iN) * basis_->get_phi(iX, iN + 1, k) * gval_ /
+                basis_->basis_eval(state, iX, 0, iN + 1) * grid.get_sqrt_gm(X);
+            local_sum_e +=
+                local_sum_v * basis_->basis_eval(state, iX, 1, iN + 1);
+          }
+
+          dU(1, iX, k) -= (local_sum_v * grid.get_widths(iX)) /
+                          basis_->get_mass_matrix(iX, k);
+          dU(2, iX, k) -= (local_sum_e * grid.get_widths(iX)) /
+                          basis_->get_mass_matrix(iX, k);
+        });
+  } else {
+    Kokkos::parallel_for(
+        "Gravity :: Constant update",
+        Kokkos::MDRangePolicy<Kokkos::Rank<2>>({ilo, 0}, {ihi + 1, order}),
+        KOKKOS_CLASS_LAMBDA(const int iX, const int k) {
+          double local_sum_v = 0.0;
+          double local_sum_e = 0.0;
+          for (int iN = 0; iN < nNodes; ++iN) {
+            const double X = grid.node_coordinate(iX, iN);
+
+            local_sum_v +=
+                grid.get_weights(iN) * basis_->get_phi(iX, iN + 1, k) * gval_ /
+                basis_->basis_eval(state, iX, 0, iN + 1) * grid.get_sqrt_gm(X);
+            local_sum_e +=
+                local_sum_v * basis_->basis_eval(state, iX, 1, iN + 1);
+          }
+
+          dU(1, iX, k) -= (local_sum_v * grid.get_widths(iX)) /
+                          basis_->get_mass_matrix(iX, k);
+          dU(2, iX, k) -= (local_sum_e * grid.get_widths(iX)) /
+                          basis_->get_mass_matrix(iX, k);
+        });
+  }
+}
+
+/**
+ * @brief Gravitational timestep restriction
+ * @note This just returns max dt
+ **/
+KOKKOS_FUNCTION
+auto GravityPackage::min_timestep(const View3D<double> /*state*/,
+                                  const GridStructure& /*grid*/,
+                                  const TimeStepInfo& /*dt_info*/) const
+    -> double {
+  static constexpr double MAX_DT = std::numeric_limits<double>::max() / 100.0;
+  static constexpr double dt_out = MAX_DT;
+  return dt_out;
+}
+
+[[nodiscard]] KOKKOS_FUNCTION auto GravityPackage::name() const noexcept
+    -> std::string_view {
+  return "Gravity";
+}
+
+[[nodiscard]] KOKKOS_FUNCTION auto GravityPackage::is_active() const noexcept
+    -> bool {
+  return active_;
+}
+
+KOKKOS_FUNCTION
+void GravityPackage::set_active(const bool active) { active_ = active; }
+
+} // namespace gravity

--- a/src/gravity/gravity_package.cpp
+++ b/src/gravity/gravity_package.cpp
@@ -51,10 +51,11 @@ void GravityPackage::gravity_update(const View3D<double> state,
           double local_sum_e = 0.0;
           for (int iN = 0; iN < nNodes; ++iN) {
             const double X = grid.node_coordinate(iX, iN);
-
-            local_sum_v +=
-                grid.get_weights(iN) * basis_->get_phi(iX, iN + 1, k) * gval_ /
-                basis_->basis_eval(state, iX, 0, iN + 1) * grid.get_sqrt_gm(X);
+            local_sum_v += constants::G_GRAV * grid.get_weights(iN) *
+                           basis_->get_phi(iX, iN + 1, k) /
+                           basis_->basis_eval(state, iX, 0, iN + 1) *
+                           grid.enclosed_mass(iX, iN) * grid.get_sqrt_gm(X) /
+                           (X * X);
             local_sum_e +=
                 local_sum_v * basis_->basis_eval(state, iX, 1, iN + 1);
           }

--- a/src/gravity/gravity_package.hpp
+++ b/src/gravity/gravity_package.hpp
@@ -1,0 +1,56 @@
+#pragma once
+/**
+ * @file gravity_package.hpp
+ * --------------
+ *
+ * @brief Gravitational source package
+ **/
+
+#include "basis/polynomial_basis.hpp"
+#include "bc/boundary_conditions_base.hpp"
+#include "geometry/grid.hpp"
+#include "pgen/problem_in.hpp"
+#include "utils/abstractions.hpp"
+
+namespace gravity {
+
+using bc::BoundaryConditions;
+
+class GravityPackage {
+ public:
+  GravityPackage(const ProblemIn* /*pin*/, GravityModel model, double gval,
+                 ModalBasis* basis, double cfl, bool active = true);
+
+  KOKKOS_FUNCTION
+  void update_explicit(const View3D<double> state, View3D<double> dU,
+                       const GridStructure& grid,
+                       const TimeStepInfo& dt_info) const;
+
+  KOKKOS_FUNCTION
+  template <GravityModel Model>
+  void gravity_update(const View3D<double> state, View3D<double> dU,
+                      const GridStructure& grid) const;
+
+  [[nodiscard]] KOKKOS_FUNCTION auto
+  min_timestep(const View3D<double> /*state*/, const GridStructure& /*grid*/,
+               const TimeStepInfo& /*dt_info*/) const -> double;
+
+  [[nodiscard]] KOKKOS_FUNCTION auto name() const noexcept -> std::string_view;
+
+  [[nodiscard]] KOKKOS_FUNCTION auto is_active() const noexcept -> bool;
+
+  KOKKOS_FUNCTION
+  void set_active(bool active);
+
+ private:
+  bool active_;
+  GravityModel model_;
+
+  double gval_; // constant gravity
+
+  ModalBasis* basis_;
+
+  double cfl_;
+};
+
+} // namespace gravity

--- a/src/packages/packages_base.hpp
+++ b/src/packages/packages_base.hpp
@@ -172,7 +172,6 @@ class PackageManager {
     auto wrapper = std::make_unique<PackageWrapper>(std::forward<T>(package));
 
     // TODO(astrobarker): emplace back
-    explicit_packages_ = {};
     if (wrapper->has_explicit()) {
       explicit_packages_.push_back(wrapper.get());
     }

--- a/src/pgen/problem_in.cpp
+++ b/src/pgen/problem_in.cpp
@@ -53,6 +53,26 @@ ProblemIn::ProblemIn(const std::string& fn) {
       in_table["bc"]["rad"]["bc_o"].value<std::string>();
   std::optional<double> cfl = in_table["problem"]["cfl"].value<double>();
 
+  // Is this a good pattern?
+  do_gravity = in_table["problem"]["do_gravity"].value_or(false);
+  if (do_gravity) {
+    if (!in_table["gravity"].is_table()) {
+      THROW_ATHELAS_ERROR(
+          "Gravity is enabled but not gravity block exists in input deck!");
+    } else {
+      gval = in_table["gravity"]["gval"].value_or(0.0);
+      const std::string gmodel =
+          in_table["gravity"]["model"].value_or("constant");
+      grav_model = (utilities::to_lower(gmodel) == "spherical")
+                       ? GravityModel::Spherical
+                       : GravityModel::Constant;
+      if (grav_model == GravityModel::Constant && gval <= 0.0) {
+        THROW_ATHELAS_ERROR(
+            "Constant gravitational potential requested but g <= 0.0!");
+      }
+    }
+  }
+
   // output
   nlim            = in_table["output"]["nlim"].value_or(-1);
   ncycle_out      = in_table["output"]["ncycle_out"].value_or(1);

--- a/src/pgen/problem_in.hpp
+++ b/src/pgen/problem_in.hpp
@@ -94,6 +94,11 @@ class ProblemIn {
   std::string hist_fn;
   double hist_dt;
 
+  // gravity
+  bool do_gravity;
+  GravityModel grav_model;
+  double gval;
+
   toml::table in_table;
 };
 

--- a/src/radiation/radhydro_package.cpp
+++ b/src/radiation/radhydro_package.cpp
@@ -40,7 +40,7 @@ KOKKOS_FUNCTION
 void RadHydroPackage::update_explicit(const View3D<double> state,
                                       View3D<double> dU,
                                       const GridStructure& grid,
-                                      const TimeStepInfo& dt_info) {
+                                      const TimeStepInfo& dt_info) const {
   // TODO(astrobarker) handle separate fluid and rad orders
   const auto& order = fluid_basis_->get_order();
   const auto& ilo   = grid.get_ilo();
@@ -86,7 +86,7 @@ KOKKOS_FUNCTION
 void RadHydroPackage::update_implicit(const View3D<double> state,
                                       View3D<double> dU,
                                       const GridStructure& grid,
-                                      const TimeStepInfo& dt_info) {
+                                      const TimeStepInfo& dt_info) const {
   // TODO(astrobarker) handle separate fluid and rad orders
   const auto& order = fluid_basis_->get_order();
   const auto& ilo   = grid.get_ilo();
@@ -166,7 +166,7 @@ KOKKOS_FUNCTION
 void RadHydroPackage::radhydro_divergence(const View3D<double> state,
                                           View3D<double> dU,
                                           const GridStructure& grid,
-                                          const int stage) {
+                                          const int stage) const {
   const auto& nNodes = grid.get_n_nodes();
   const auto& order  = rad_basis_->get_order();
   const auto& ilo    = grid.get_ilo();

--- a/src/radiation/radhydro_package.hpp
+++ b/src/radiation/radhydro_package.hpp
@@ -25,13 +25,14 @@ class RadHydroPackage {
                   BoundaryConditions* bcs, double cfl, int nx,
                   bool active = true);
 
-  // TODO(astrobarker): mark const
   KOKKOS_FUNCTION
   void update_explicit(View3D<double> state, View3D<double> dU,
-                       const GridStructure& grid, const TimeStepInfo& dt_info);
+                       const GridStructure& grid,
+                       const TimeStepInfo& dt_info) const;
   KOKKOS_FUNCTION
   void update_implicit(View3D<double> state, View3D<double> dU,
-                       const GridStructure& grid, const TimeStepInfo& dt_info);
+                       const GridStructure& grid,
+                       const TimeStepInfo& dt_info) const;
   KOKKOS_FUNCTION
   void update_implicit_iterative(View3D<double> state, View3D<double> dU,
                                  const GridStructure& grid,
@@ -43,7 +44,7 @@ class RadHydroPackage {
 
   KOKKOS_FUNCTION
   void radhydro_divergence(const View3D<double> state, View3D<double> dU,
-                           const GridStructure& grid, int stage);
+                           const GridStructure& grid, int stage) const;
 
   [[nodiscard]] KOKKOS_FUNCTION auto
   min_timestep(const View3D<double> state, const GridStructure& grid,
@@ -93,11 +94,8 @@ class RadHydroPackage {
   static constexpr int NUM_VARS_ = 5;
 };
 
-auto compute_increment_radhydro_source(const View2D<double> uCRH, const int k,
-                                       const GridStructure& grid,
-                                       const ModalBasis* fluid_basis,
-                                       const ModalBasis* rad_basis,
-                                       const EOS* eos, const Opacity* opac,
-                                       const int iX)
-    -> std::tuple<double, double, double, double>;
+auto compute_increment_radhydro_source(
+    const View2D<double> uCRH, int k, const GridStructure& grid,
+    const ModalBasis* fluid_basis, const ModalBasis* rad_basis, const EOS* eos,
+    const Opacity* opac, int iX) -> std::tuple<double, double, double, double>;
 } // namespace radiation

--- a/src/timestepper/timestepper.hpp
+++ b/src/timestepper/timestepper.hpp
@@ -121,6 +121,7 @@ class TimeStepper {
           });
 
       auto stage_data_j = Kokkos::subview(stage_data_, iS, Kokkos::ALL);
+      grid_s_[iS]       = grid;
       grid_s_[iS].update_grid(stage_data_j);
 
       auto Us_j =
@@ -159,6 +160,7 @@ class TimeStepper {
                 integrator_.explicit_tableau.b_i(iS);
           });
       auto stage_data_j = Kokkos::subview(stage_data_, 0, Kokkos::ALL);
+      grid_s_[iS]       = grid;
       grid_s_[iS].update_grid(stage_data_j);
     }
 
@@ -259,6 +261,7 @@ class TimeStepper {
       } // End inner loop
 
       auto stage_data_j = Kokkos::subview(stage_data_, iS, Kokkos::ALL);
+      grid_s_[iS]       = grid;
       grid_s_[iS].update_grid(stage_data_j);
 
       // set U_s
@@ -376,6 +379,7 @@ class TimeStepper {
             stage_data_(iS, iX) += dt_b * flux_u_i(iX);
           });
       auto stage_data_j = Kokkos::subview(stage_data_, iS, Kokkos::ALL);
+      grid_s_[iS]       = grid;
       grid_s_[iS].update_grid(stage_data_j);
     }
 

--- a/src/utils/abstractions.hpp
+++ b/src/utils/abstractions.hpp
@@ -45,3 +45,4 @@ struct TimeStepInfo {
   double dt_a; // dt * tableau coefficient
   int stage;
 };
+enum class GravityModel { Constant, Spherical };

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -15,19 +15,19 @@
 
 namespace constants {
 
-constexpr double PI       = std::numbers::pi;
-constexpr double G_GRAV   = 6.674299999999999e-8; // cgs
-constexpr double L_sun    = 3.828e33; // cgs
-constexpr double M_sun    = 1.98840987e+33; // cgs
-constexpr double sigma_sb = 5.670374419184431e-5; // cgs
-constexpr double a        = 7.5657332502800007e-15; // cgs
-constexpr double k_B      = 1.380649e-16; // cgs
-constexpr double m_e      = 9.1093837015e-28; // cgs
-constexpr double m_p      = 1.67262192369e-24; // cgs
-constexpr double h        = 6.62607015e-27; // cgs
-constexpr double hbar     = 1.05457182e-27; // cgs
-constexpr double N_A      = 6.02214076e+23; // 1 / mol
-constexpr double c_cgs    = 2.99792458e+10; // cgs
-constexpr double c        = 1.0; // natural
+static constexpr double PI       = std::numbers::pi;
+static constexpr double G_GRAV   = 6.674299999999999e-8; // cgs
+static constexpr double L_sun    = 3.828e33; // cgs
+static constexpr double M_sun    = 1.98840987e+33; // cgs
+static constexpr double sigma_sb = 5.670374419184431e-5; // cgs
+static constexpr double a        = 7.5657332502800007e-15; // cgs
+static constexpr double k_B      = 1.380649e-16; // cgs
+static constexpr double m_e      = 9.1093837015e-28; // cgs
+static constexpr double m_p      = 1.67262192369e-24; // cgs
+static constexpr double h        = 6.62607015e-27; // cgs
+static constexpr double hbar     = 1.05457182e-27; // cgs
+static constexpr double N_A      = 6.02214076e+23; // 1 / mol
+static constexpr double c_cgs    = 2.99792458e+10; // cgs
+static constexpr double c        = 1.0; // natural
 
 } // namespace constants

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -16,7 +16,7 @@
 namespace constants {
 
 static constexpr double PI       = std::numbers::pi;
-static constexpr double FOURPI       = 4.0 * std::numbers::pi;
+static constexpr double FOURPI   = 4.0 * std::numbers::pi;
 static constexpr double G_GRAV   = 6.674299999999999e-8; // cgs
 static constexpr double L_sun    = 3.828e33; // cgs
 static constexpr double M_sun    = 1.98840987e+33; // cgs

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -16,6 +16,7 @@
 namespace constants {
 
 static constexpr double PI       = std::numbers::pi;
+static constexpr double FOURPI       = 4.0 * std::numbers::pi;
 static constexpr double G_GRAV   = 6.674299999999999e-8; // cgs
 static constexpr double L_sun    = 3.828e33; // cgs
 static constexpr double M_sun    = 1.98840987e+33; // cgs


### PR DESCRIPTION
Adds a `Gravity` explicit package. Currently, gravity supports two modes: `constant` and `spherical`. For constant gravity, there is just a simple source term `\rho g`. For spherical gravity, we do the full - GM/r^2 source term. This is toggled/enabled in the input deck:
```
[problem]
do_gravity = true

[gravity]
model = "constant" # or spherical
gval = 2.0
```
The physics has produced some stuff that seems correct, but requires better test problems.