### PR TITLE
refactor hdf5 out

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -30,7 +30,7 @@ auto Driver::execute() -> int {
               pin_->param()->get<int>("fluid.porder"),
               pin_->param()->get<std::string>("problem.problem"));
   print_simulation_parameters(grid_, pin_.get());
-  write_state(&state_, grid_, &sl_hydro_, problem_name, time_,
+  write_state(&state_, grid_, &sl_hydro_, pin_.get(), time_,
               pin_->param()->get<int>("fluid.porder"), 0, opts_.do_rad);
 
   // --- Timer ---
@@ -83,7 +83,7 @@ auto Driver::execute() -> int {
     } catch (const AthelasError& e) {
       std::cerr << e.what() << std::endl;
       std::println("!!! Bad State found, writing _final_ output file ...");
-      write_state(&state_, grid_, &sl_hydro_, problem_name, time_,
+      write_state(&state_, grid_, &sl_hydro_, pin_.get(), time_,
                   pin_->param()->get<int>("fluid.porder"), -1, opts_.do_rad);
       return AthelasExitCodes::FAILURE;
     }
@@ -94,7 +94,7 @@ auto Driver::execute() -> int {
     // Write state, other io
     if (time_ >= i_out_h5 * dt_hdf5) {
       fill_derived(&state_, eos_.get(), &grid_, fluid_basis_.get());
-      write_state(&state_, grid_, &sl_hydro_, problem_name, time_,
+      write_state(&state_, grid_, &sl_hydro_, pin_.get(), time_,
                   fluid_basis_->get_order(), i_out_h5, opts_.do_rad);
       i_out_h5 += 1;
     }
@@ -117,7 +117,7 @@ auto Driver::execute() -> int {
   }
 
   fill_derived(&state_, eos_.get(), &grid_, fluid_basis_.get());
-  write_state(&state_, grid_, &sl_hydro_, problem_name, time_,
+  write_state(&state_, grid_, &sl_hydro_, pin_.get(), time_,
               pin_->param()->get<int>("fluid.porder"), -1, opts_.do_rad);
 
   return AthelasExitCodes::SUCCESS;

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -22,3 +22,7 @@ auto Params::keys() const -> std::vector<std::string> {
   }
   return result;
 }
+
+auto Params::get_type(const std::string& key) const -> std::type_index {
+  return params_.at(key)->type();
+}

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -10,6 +10,7 @@
 
 #include <any>
 #include <string>
+#include <typeindex>
 #include <unordered_map>
 
 #include "utils/error.hpp"
@@ -127,6 +128,7 @@ class Params {
   void remove(const std::string& key);
   void clear();
   auto keys() const -> std::vector<std::string>;
+  auto get_type(const std::string& key) const -> std::type_index;
 
  private:
   std::unordered_map<std::string, std::unique_ptr<std::any>> params_;

--- a/src/io/io.hpp
+++ b/src/io/io.hpp
@@ -23,9 +23,9 @@ struct DataType {
   double x{};
 };
 
-void write_state(State* state, GridStructure grid, SlopeLimiter* SL,
-                 const std::string& problem_name, double time, int order,
-                 int i_write, bool do_rad);
+void write_state(State* state, GridStructure& grid, SlopeLimiter* SL,
+                 ProblemIn* pin, double time, int order, int i_write,
+                 bool do_rad);
 
 void print_simulation_parameters(GridStructure grid, ProblemIn* pin);
 


### PR DESCRIPTION
## PR Summary
Massive cleanup of HDF5 output. somewhat readable and extendable. Output params into a dataset. Probably should be attributes but this is just easier to work with. Added a `get_type` class to params. For params, currently only strings, ints, doubles are output. that's all that should be kept in the main pin params anyway. There are a coupled of enums that will have to be dealt with at restart time.
